### PR TITLE
items details page implement

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,14 +41,14 @@ class ItemsController < ApplicationController
   #    redirect_to items_path
   #  end
 
-  #  def show
-  #  end
+  def show
+  end
 
   private
 
-  #  def find_item
-  #    @item = Item.find(params[:id])
-  #  end
+  def find_item
+    @item = Item.find(params[:id])
+  end
 
   def item_params
     params.require(:item).permit(

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,63 +1,53 @@
 # # COMMENTED OUTED
-#
-# class OrdersController < ApplicationController
-#   def index
-#     @order = Order.new
-#   end
-#
-#   def create
-#     @order = Order.new(order_params)
-#     if @order.valid?
-#       pay_item
-#       @order.save
-#       redirect_to root_path
-#     else
-#       render 'index'
-#     end
-#   end
-#
-#   #  def index
-#   #    @order = Order.new
-#   #  end
-#
-#   #  def create
-#   #    @order = current_user.orders.build(item_id: params[:item_id])
-#   #    @order = Order.new(order_params)
-#   #    if @order.valid?
-#   #      pay_item
-#   #      @order.save
-#   #      redirect_to root_path
-#   #    else
-#   #     render 'index'
-#   #    end
-#   #  end
-#
-#   #  private
-#
-#   #  def order_params
-#   #    params.require(:order).permit(:price).merge(token: params[:token])
-#   #  end
-#
-#   def order_params
-#     params.require(:order).permit(:price).merge(token: params[:token])
-#   end
-#
-#   def pay_item
-#     Payjp.api_key = ENV['PAYJP_SECRET_KEY']
-#     Payjp::Charge.create(
-#       amount: order_params[:price],  # 商品の値段
-#       card: order_params[:token],    # カードトークン
-#       currency: 'jpy' # 通貨の種類（日本円）
-#     )
-#   end
-# end
-#
-# #  def pay_item
-# #    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
-# #    Payjp::Charge.create(
-# #     amount: order_params[:price],  # 商品の値段
-# #      card: order_params[:token],    # カードトークン
-# #      currency: 'jpy'                 # 通貨の種類（日本円）
-# #    )
-# #  end
-# # end
+
+class OrdersController < ApplicationController
+  def index
+    @order = Order.new
+  end
+
+  def new
+    @order = Order.new
+    @item = Item.find(params[:item_id])
+  end
+
+  def create
+    # Uncomment and adjust order_params as needed
+    @order = Order.new(order_params)
+    if @order.valid?
+      # Uncomment and adjust the payment processing code (pay_item) as needed
+      # pay_item
+      @order.save
+      redirect_to root_path, notice: 'Order was successfully created.'
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+  def order_params
+    # Uncomment and adjust the permitted parameters and token as needed
+    # params.require(:order).permit(:price).merge(token: params[:token])
+    params.require(:order).permit(:price) # Example, you can add :token if needed
+  end
+
+  #
+  #   def pay_item
+  #     Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+  #     Payjp::Charge.create(
+  #       amount: order_params[:price],  # 商品の値段
+  #       card: order_params[:token],    # カードトークン
+  #       currency: 'jpy' # 通貨の種類（日本円）
+  #     )
+  #   end
+  # end
+  #
+  # #  def pay_item
+  # #    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+  # #    Payjp::Charge.create(
+  # #     amount: order_params[:price],  # 商品の値段
+  # #      card: order_params[:token],    # カードトークン
+  # #      currency: 'jpy'                 # 通貨の種類（日本円）
+  # #    )
+  # #  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  # has_one :order
+  has_one :order
 
   # Image presence validation
   validates :image, presence: { message: "can't be blank" }
@@ -38,7 +38,7 @@ class Item < ApplicationRecord
                       message: 'は¥300以上、¥9,999,999以下で入力してください'
                     }
 
-  #  def sold_out?
-  #    # order.present? || sold
-  #  end
+  def sold_out?
+    order.present?
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  has_one :order
+  #  has_one :order
 
   # Image presence validation
   validates :image, presence: { message: "can't be blank" }
@@ -38,7 +38,7 @@ class Item < ApplicationRecord
                       message: 'は¥300以上、¥9,999,999以下で入力してください'
                     }
 
-  def sold_out?
-    order.present?
-  end
+  #  def sold_out?
+  #    order.present?
+  #  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,12 +1,12 @@
-class Order < ApplicationRecord
-  attr_accessor :token
+# class Order < ApplicationRecord
+#   attr_accessor :token
 
-  validates :price, presence: true
-  validates :token, presence: true
+#   validates :price, presence: true
+#   validates :token, presence: true
 
-  belongs_to :user
-  belongs_to :item
-  has_one :shipping_address, dependent: :destroy
+#   belongs_to :user
+#   belongs_to :item
+#   has_one :shipping_address, dependent: :destroy
 
-  # You probably don't need to validate user_id and item_id as they are managed by Rails through belongs_to
-end
+#   # You probably don't need to validate user_id and item_id as they are managed by Rails through belongs_to
+# end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,15 +1,12 @@
-# # COMMENTED OUTED
-#
-# class Order < ApplicationRecord
-#   attr_accessor :token
-#
-#   validates :price, presence: true
-#   validates :token, presence: true
-# end
-#
-# belongs_to :user
-# belongs_to :item
-# has_one :shipping_address, dependent: :destroy
-#
-# #  # You probably don't need to validate user_id and item_id as they are managed by Rails through belongs_to
-# # end
+class Order < ApplicationRecord
+  attr_accessor :token
+
+  validates :price, presence: true
+  validates :token, presence: true
+
+  belongs_to :user
+  belongs_to :item
+  has_one :shipping_address, dependent: :destroy
+
+  # You probably don't need to validate user_id and item_id as they are managed by Rails through belongs_to
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,6 +1,5 @@
 <%= render "shared/header" %>
 <div class='main'>
-
   <!-- 画面上部の「人生を変えるフリマアプリ」帯部分 -->
   <div class='title-contents'>
     <h2 class='service-title'>
@@ -17,7 +16,7 @@
       <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <!-- /画面上部の「人生を変えるフリマアプリ」帯部分  -->
+  <!-- /画面上部の「人生を変えるフリマアプリ」帯部分 -->
 
   <!-- FURIMAが選ばれる3つの理由部分 -->
   <div class='select-reason-contents'>
@@ -128,10 +127,10 @@
     </div>
     <ul class='item-lists'>
       <!-- Check if @items is not empty -->
- --     <% if @items.present? %>
+      <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to item_path(item) do %> 
+            <%= link_to item_path(item) do %>
               <div class='item-img-content'>
                 <!-- Display the item image if available, else show a default image -->
                 <% if item.image.attached? %>
@@ -140,35 +139,36 @@
                   <%= image_tag "item-sample.png", class: "item-img" %>
                 <% end %>
 
-                <% if item.sold_out? %> 
-                  <div class='sold-out'>
-                    <span>Sold Out!!</span>
-                  </div>
-                <% end %>
+<%#   <% if item.sold_out? %>
+<%#         <div class='sold-out'>
+            <%#   <span>Sold Out!!</span>
+          </div>
+<%#  <% end %>
+
               </div>
               <!-- Display item name, price, and delivery fee -->
-<div class='item-info'>
-  <h3 class='item-name'>
-    <%= item.name %>
-  </h3>
-  <div class='item-price'>
-    <span><%= item.price %>円<br>
-    <% delivery_fee = DeliveryFee.find(item.delivery_fee_id) %>
-    <%= delivery_fee.name %></span>
-    <div class='star-btn'>
-      <%= image_tag "star.png", class: "star-icon" %>
-      <span class='star-count'>0</span>
-    </div>
-  </div>
-</div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br>
+                  <% delivery_fee = DeliveryFee.find(item.delivery_fee_id) %>
+                  <%= delivery_fee.name %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class: "star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
             <% end %>
           </li>
         <% end %>
-      <!-- If @items is empty, display dummy items -->
-      <% else %>
+      <% else %> 
+        <!-- If @items is empty, display dummy items -->
         <!-- Display a placeholder item if there are no items -->
         <li class='list'>
-          <%= link_to '#' do %>
+          <%= link_to new_item_path do %> 
             <!-- Display a placeholder image and text -->
             <div class='item-img-content'>
               <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,10 +128,10 @@
     </div>
     <ul class='item-lists'>
       <!-- Check if @items is not empty -->
- <!--     <% if @items.present? %>
+ --     <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to item_path(item) do %>    -->
+            <%= link_to item_path(item) do %> 
               <div class='item-img-content'>
                 <!-- Display the item image if available, else show a default image -->
                 <% if item.image.attached? %>
@@ -140,8 +140,7 @@
                   <%= image_tag "item-sample.png", class: "item-img" %>
                 <% end %>
 
-                <!-- Display 'Sold Out!!' if the item is sold out 
-                <% if item.sold_out? %>  -->
+                <% if item.sold_out? %> 
                   <div class='sold-out'>
                     <span>Sold Out!!</span>
                   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 <% if user_signed_in? %>
   <% if current_user == @item.user %>
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
@@ -42,7 +41,6 @@
   <% end %>
 <% end %>
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,4 +1,4 @@
-<!---
+
 
 <%= render "shared/header" %>
 
@@ -16,7 +16,7 @@
       <% end %>
     </div>
 
-<% if @item.sold_out? %>  
+<% if @item.sold_out? %>
   <div class="sold-out">
     <span>Sold Out!!</span>
   </div>
@@ -34,20 +34,23 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && current_user == @item.user %>
-      <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to "削除", @item, method: :delete, data: { confirm: 'Are you sure?' }, class: "item-destroy" %>
-    <% else %>
-      <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%= link_to "購入画面に進む", new_order_path(item_id: @item.id), class: "item-red-btn" %>
+<% if user_signed_in? && current_user == @item.user %>
+  <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+  <p class="or-text">or</p>
+  <%= link_to "削除", @item, method: :delete, data: { confirm: 'Are you sure?' }, class: "item-destroy" %>
+<% elsif !@item.sold_out? %>
+       <%# 商品が売れていない場合はこちらを表示しましょう %>
+  <%= link_to "購入画面に進む", new_order_path(item_id: @item.id), class: "item-red-btn" %>
       <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <% end %>
+<% else %>
+  <!-- Display a message or a link to log in/register -->
+  <%= link_to "ログインして購入する", new_user_session_path, class: "item-red-btn" %>
+<% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -88,8 +91,33 @@
       </div>
     </div>
   </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>
-
---->

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,13 +16,11 @@
       <% end %>
     </div>
 
-<% if @item.sold_out? %>
-  <div class="sold-out">
-    <span>Sold Out!!</span>
-  </div>
-<% end %>
-
-<%# //商品が売れている場合は、sold outを表示しましょう %>
+<%#   <% if item.sold_out? %>
+<%#         <div class='sold-out'>
+            <%#   <span>Sold Out!!</span>
+          </div>
+<%#  <% end %>
 
     <div class="item-price-box">
       <span class="item-price">
@@ -112,9 +110,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,17 +34,14 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-<% if user_signed_in? && current_user == @item.user %>
-  <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
-  <p class="or-text">or</p>
-  <%= link_to "削除", @item, method: :delete, data: { confirm: 'Are you sure?' }, class: "item-destroy" %>
-<% elsif !@item.sold_out? %>
-       <%# 商品が売れていない場合はこちらを表示しましょう %>
-  <%= link_to "購入画面に進む", new_order_path(item_id: @item.id), class: "item-red-btn" %>
-      <%# //商品が売れていない場合はこちらを表示しましょう %>
-<% else %>
-  <!-- Display a message or a link to log in/register -->
-  <%= link_to "ログインして購入する", new_user_session_path, class: "item-red-btn" %>
+<% if user_signed_in? %>
+  <% if current_user == @item.user %>
+    <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+    <p class="or-text">or</p>
+    <%= link_to "削除", @item, method: :delete, data: { confirm: 'Are you sure?' }, class: "item-destroy" %>
+  <% elsif !@item.sold_out? %>
+    <%= link_to "購入画面に進む", new_order_path(item_id: @item.id), class: "item-red-btn" %>
+  <% end %>
 <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   end
 
   resources :orders, only: [:create]
+  get '/orders/new/:item_id', to: 'orders#new', as: 'new_order'
+
 
   resources :users, constraints: { id: /\d+/ } do
     resources :orders, only: [:index, :show, :new, :create]


### PR DESCRIPTION
WHAT
商品詳細表示機能

WHY
商品詳細表示機能 実装の為

https://github.com/Aryokonon/furima-39415/pull/16

https://docs.google.com/forms/d/e/1FAIpQLScy6cm9WRPwIxPmWBEc5AP8o-f7_BjmlARjd_qexh10-vYN3A/viewform

プルリクエストへ記載するgyazo
 ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/8e8fa03fddd3618f202ed0cd6e4adc00

 ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/dd8e07cc7360269a1c7812241f720a6b

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
まだ。その実装の時に動画とって送ります。

ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。
売却済みの商品は、画像上に「sold out」の文字が表示されること。

 ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/35796456262f2d063b07612f5530b4ff